### PR TITLE
add duckdb parquet generation

### DIFF
--- a/.github/workflows/process_new_build_reports.yaml
+++ b/.github/workflows/process_new_build_reports.yaml
@@ -97,6 +97,6 @@ jobs:
               TYPE S3,
               PROVIDER CREDENTIAL_CHAIN
           );
-          COPY (SELECT * FROM read_csv_auto('s3://bioc-builddb-mirror/buildResults/*info.csv.gz')) TO 'report_dir/parquet/info.parquet' (FORMAT PARQUET, compression zstd);
-          COPY (SELECT * FROM read_csv_auto('s3://bioc-builddb-mirror/buildResults/*propagation_status.csv.gz')) TO 'report_dir/parquet/propagation_status.parquet' (FORMAT PARQUET, compression zstd);
-          COPY (SELECT * FROM read_csv_auto('s3://bioc-builddb-mirror/buildResults/*build_summary.csv.gz')) TO 'report_dir/parquet/build_summary.parquet' (FORMAT PARQUET, compression zstd);"
+          COPY (SELECT * FROM read_csv_auto('s3://bioc-builddb-mirror/buildResults/*info.csv.gz')) TO 's3://bioc-builddb-mirror/parquet/info.parquet' (FORMAT PARQUET, compression zstd);
+          COPY (SELECT * FROM read_csv_auto('s3://bioc-builddb-mirror/buildResults/*propagation_status.csv.gz')) TO 's3://bioc-builddb-mirror/parquet/propagation_status.parquet' (FORMAT PARQUET, compression zstd);
+          COPY (SELECT * FROM read_csv_auto('s3://bioc-builddb-mirror/buildResults/*build_summary.csv.gz')) TO 's3://bioc-builddb-mirror/parquet/build_summary.parquet' (FORMAT PARQUET, compression zstd);"


### PR DESCRIPTION
## Overview

This PR adds to GitHub Actions workflow the ability to store parquet "tables" to AWS S3. The workflow runs daily. 

It uses duckdb and the AWS identity federation to read all the separate CSV files in cloud storage and writes them back to AWS s3 as parquet files.

## Files created

- https://bioc-builddb-mirror.s3.amazonaws.com/parquet/info.parquet
- https://bioc-builddb-mirror.s3.amazonaws.com/parquet/build_summary.parquet
- https://bioc-builddb-mirror.s3.amazonaws.com/parquet/propagation_status.parquet

## Downstream usage

For the `info` table from R, here is an example. For other tables, similar workflow will work. You can also use duckdb with the same urls if that more suits your needs. 

```r
library(arrow)
info_table <- read_parquet('https://bioc-builddb-mirror.s3.amazonaws.com/parquet/info.parquet')
head(info_table)
dim(info_table)
```

```
> head(info_table)
              Package Version     Maintainer               MaintainerEmail
1          adductData  1.26.0    Josie Hayes      jlhayes1982 at gmail.com
2        affycompData  1.48.0 Robert D Shear rshear at ds.dfci.harvard.edu
3            affydata  1.58.0 Robert D Shear rshear at ds.dfci.harvard.edu
4    Affyhgu133A2Expr  1.46.0    Zhicheng Ji               zji4 at jhu.edu
5     Affyhgu133aExpr  1.48.0    Zhicheng Ji               zji4 at jhu.edu
6 Affyhgu133Plus2Expr  1.44.0    Zhicheng Ji               zji4 at jhu.edu
                                                    git_url   git_branch
1          https://git.bioconductor.org/packages/adductData RELEASE_3_22
2        https://git.bioconductor.org/packages/affycompData RELEASE_3_22
3            https://git.bioconductor.org/packages/affydata RELEASE_3_22
4    https://git.bioconductor.org/packages/Affyhgu133A2Expr RELEASE_3_22
5     https://git.bioconductor.org/packages/Affyhgu133aExpr RELEASE_3_22
6 https://git.bioconductor.org/packages/Affyhgu133Plus2Expr RELEASE_3_22
  git_last_commit git_last_commit_date                       report_md5
1         371b0e2  2025-10-29 15:01:12 0015761b48700798e7a4cc3e0d5a3e00
2         45dff8f  2025-10-29 14:32:05 0015761b48700798e7a4cc3e0d5a3e00
3         10b07a5  2025-10-29 14:23:07 0015761b48700798e7a4cc3e0d5a3e00
4         3087443  2025-10-29 14:54:47 0015761b48700798e7a4cc3e0d5a3e00
5         404c1b6  2025-10-29 14:54:40 0015761b48700798e7a4cc3e0d5a3e00
6         2df08dd  2025-10-29 14:54:50 0015761b48700798e7a4cc3e0d5a3e00
> dim(info_table)
[1] 1122746       9
```

